### PR TITLE
remove unused variables and todo

### DIFF
--- a/Assets/BoundingsTimeout2D.cs
+++ b/Assets/BoundingsTimeout2D.cs
@@ -15,7 +15,6 @@ public class BoundingsTimeout2D : MonoBehaviour
 		if (time > timeout)
 			Destroy (this.gameObject);
 
-        // TODO: same checks in Boundings2D.cs. Can modularize
 		var left = Camera.main.ViewportToWorldPoint(Vector3.zero).x;
 		var right = Camera.main.ViewportToWorldPoint(Vector3.one).x;
 		var top = Camera.main.ViewportToWorldPoint(Vector3.zero).y;
@@ -23,9 +22,6 @@ public class BoundingsTimeout2D : MonoBehaviour
 
 		bool xout = false;
 		bool yout = false;
-
-		float x = transform.position.x;
-		float y = transform.position.y;
 
 		// check x
 		if (transform.position.x <= left - GetComponentInChildren<Renderer>().bounds.size.x) {


### PR DESCRIPTION
removed unused variables and the modularization todo.

didn't realize this yesterday, but I am not entirely sure we can modularize the two, the checks are actually different. Boundings checks _left_ of sprite vs left wall (to keep it in) where timeout checks the _right_ of sprite vs the left wall (to see if it is entirely outside). Same for the rest of the checks, they are opposite sides. If you still have an idea on that go ahead and replace it, but the checks are definitely different between the two.
