### PR TITLE
add team class

### DIFF
--- a/Assets/Team.cs
+++ b/Assets/Team.cs
@@ -1,0 +1,39 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class Team : MonoBehaviour {
+
+	public enum teams {
+		friendly,	// player team
+		enemy,		// non-player team
+		neutral,	// neither team (either can attack)
+		none		// no team (can't attack), same state as not having this script attached
+	}
+
+	public teams team = teams.none;
+
+	int GetTeam() {
+		return (int)this.team;
+	}
+
+	void SetTeam(teams team) {
+		this.team = team;
+	}
+
+	bool IsFriendly(Team otherTeam) {
+		if (team == otherTeam.team)
+			return true;
+		else
+			return false;
+	}
+
+	// as stated above, none should be treated the same as not having this script attached
+	// if (GetComponent<Team>()) will be false for case of null (no script) AND team == none
+	public static implicit operator bool(Team team)
+	{
+		if (team.team == teams.none)
+			return false;
+		else
+			return true;
+	}
+}

--- a/Assets/Team.cs.meta
+++ b/Assets/Team.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cb51eadc9b69b45e2bf84b550f277e3e
+timeCreated: 1466916989
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds Team script. Having a team of none is equivalent to not having the script (see below). It exists for cases where either the team may change explicitly to / from none, whereas not having the script is implicitly not having a team.
Example usage:

```
team = enemy.GetComponent<Team>();
// if has team and team is not friendly with this team
if (team && !team.IsFriendly(this.team)) {
  Attack(enemy);
}
```

Note that GetCompenent<Type>() returns null when there is no component found, and null evaluates to false. The following check `if(team)` is false in either case of no script, or team == none.

Thoughts on adding an IsEnemy function? It would just be the opposite of IsFriendly, but might be nice for readability over using !IsFriendly...

Also this does not actually add any usage of the added class yet (i.e. no prefabs with it or any checks of it).
