### PR TITLE
add snap functionality

### DIFF
--- a/Assets/Editor/WaveEditor.cs
+++ b/Assets/Editor/WaveEditor.cs
@@ -4,10 +4,17 @@ using UnityEditor;
 [CustomEditor(typeof(Wave))]
 public class WaveHandleEditor : Editor
 {
+	bool snap = true;
+	float snapTo = .5f;
+
 	public override void OnInspectorGUI ()
 	{
 		serializedObject.Update();
+
+		snap = EditorGUILayout.Toggle ("Snap", snap);
+		snapTo = EditorGUILayout.FloatField ("Snap To", snapTo);
 		WaveList.Show(serializedObject.FindProperty("spawnables"));
+
 		serializedObject.ApplyModifiedProperties();
 	}
 
@@ -66,6 +73,13 @@ public class WaveHandleEditor : Editor
 			}
 
 			Vector3 position = Handles.PositionHandle (new Vector3 (x + wave.transform.position.x, y, 0), rotation);
+
+			// snap check
+			if (snap)
+			{	//round(X / N)*N
+				position.x = (float)System.Math.Round(position.x / snapTo) * snapTo;
+				position.y = (float)System.Math.Round(position.y / snapTo) * snapTo;
+			}
 
 			if (EditorGUI.EndChangeCheck())
 			{


### PR DESCRIPTION
Added a toggle in the inspector to enable / disable snapping. The SnapTo will snap to the nearest value defined. For example 1 will snap every 1 (0, 1, 2), 2 will snap every 2 (0, 2, 4), and .5 will snap every .5 (0, .5, 1). SnapTo effectively determines the distance between snap points.
