### PR TITLE
use time starting from screen visibility

### DIFF
--- a/Assets/EnemyMovement.cs
+++ b/Assets/EnemyMovement.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using System.Collections;
 using UnityEditor;
+using System.Linq;
+using System;
 
 public class EnemyMovement : MonoBehaviour
 {
@@ -28,10 +30,18 @@ public class EnemyMovement : MonoBehaviour
 
 	Rigidbody2D rbody;
 
+	public float startTime = 0;
+
+	float LocalTime () {
+		return Time.time - startTime;
+	}
+
 	// Use this for initialization
 	void Start ()
 	{
 		rbody = gameObject.GetComponent<Rigidbody2D> ();
+
+		startTime = Time.time;
 	}
 	
 	// Update is called once per frame
@@ -43,20 +53,20 @@ public class EnemyMovement : MonoBehaviour
 		switch ((int)xModifier)
 		{
 		case (int)modifiers.sin:
-			x += Mathf.Sin ((Time.time + xModifierOffset) * xModifierRate) * xModifierVelocity;
+			x += Mathf.Sin ((LocalTime() + xModifierOffset) * xModifierRate) * xModifierVelocity;
 			break;
 		case (int)modifiers.cos:
-			x += Mathf.Cos ((Time.time + xModifierOffset) * xModifierRate) * xModifierVelocity;
+			x += Mathf.Cos ((LocalTime() + xModifierOffset) * xModifierRate) * xModifierVelocity;
 			break;
 		}
 
 		switch ((int)yModifier)
 		{
 		case (int)modifiers.sin:
-			y += Mathf.Sin ((Time.time + yModifierOffset) * yModifierRate) * yModifierVelocity;
+			y += Mathf.Sin ((LocalTime() + yModifierOffset) * yModifierRate) * yModifierVelocity;
 			break;
 		case (int)modifiers.cos:
-			y += Mathf.Cos ((Time.time + yModifierOffset) * yModifierRate) * yModifierVelocity;
+			y += Mathf.Cos ((LocalTime() + yModifierOffset) * yModifierRate) * yModifierVelocity;
 			break;
 		}
 


### PR DESCRIPTION
with Start it sets a local, private, startTime variable with the current time. It then uses this against real time to figure out its algorithmic movements.

This causes, for example, a line of enemies using Sin/Cos to, instead of moving all together, move in what would appear to be a snake-like movement (due to each starting from 0 due to this time change, instead of starting at whatever the Time currently is).

This also means enemy movements when entering the screen are consistent, regardless of _when_ they enter the screen.

I implemented a hack to the Enemy script for the "on screen enable" stuff to test this, though that is not part of this PR.
#61

Note: This is done in Start instead of OnEnable as mentioned in #61. Apparently component.enabled = true causes both OnEnable AND Start to be called. Due to this there is no reason not to just put that in Start (I previously expected Start to be called only on instantiation, with OnEnable reacting to component.enabled = true).
