### PR TITLE
Enemy disabled till visible

### DIFF
--- a/Assets/Enemy.cs
+++ b/Assets/Enemy.cs
@@ -1,5 +1,11 @@
 ﻿using UnityEngine;
 
+
+[RequireComponent (typeof(Rigidbody))]
+[RequireComponent (typeof(Health))]
+[RequireComponent (typeof(EnemyMovement))]
+[RequireComponent (typeof(BoundingsTimeout2D))]
+[RequireComponent (typeof(SpriteRenderer))]
 public class Enemy : MonoBehaviour
 {
     Health health;
@@ -25,10 +31,10 @@ public class Enemy : MonoBehaviour
         rbody = this.GetComponent<Rigidbody2D> ();
 
         movement = this.GetComponent<EnemyMovement> ();
-        if (movement) movement.enabled = false;
+        movement.enabled = false;
 
         boundingstimeout = this.GetComponent<BoundingsTimeout2D> ();
-        if (boundingstimeout) boundingstimeout.enabled = false;
+        boundingstimeout.enabled = false;
 
         spriterenderer = this.GetComponent<SpriteRenderer> ();
     }

--- a/Assets/Enemy.cs
+++ b/Assets/Enemy.cs
@@ -25,10 +25,10 @@ public class Enemy : MonoBehaviour
         rbody = this.GetComponent<Rigidbody2D> ();
 
         movement = this.GetComponent<EnemyMovement> ();
-        movement.enabled = false;
+        if (movement) movement.enabled = false;
 
         boundingstimeout = this.GetComponent<BoundingsTimeout2D> ();
-        boundingstimeout.enabled = false;
+        if (boundingstimeout) boundingstimeout.enabled = false;
 
         spriterenderer = this.GetComponent<SpriteRenderer> ();
     }

--- a/Assets/Enemy.cs
+++ b/Assets/Enemy.cs
@@ -42,8 +42,7 @@ public class Enemy : MonoBehaviour
         }
         else
         {
-            if (weapon)
-                weapon.Shoot ();
+            if (weapon) weapon.Shoot ();
         }
     }
 

--- a/Assets/Enemy.cs
+++ b/Assets/Enemy.cs
@@ -5,6 +5,11 @@ public class Enemy : MonoBehaviour
     Health health;
     public Weapon weapon;
     Rigidbody2D rbody;
+    EnemyMovement movement;
+    BoundingsTimeout2D boundingstimeout;
+    SpriteRenderer spriterenderer;
+
+    bool spawned = false;
 
     // Use this for initialization
     void Start ()
@@ -13,16 +18,38 @@ public class Enemy : MonoBehaviour
 
         if (weapon)
         {
-            weapon = Instantiate(weapon, new Vector3(this.gameObject.transform.position.x, this.gameObject.transform.position.y, 0), Quaternion.identity) as Weapon;
-            weapon.transform.SetParent(this.gameObject.transform);
+            weapon = Instantiate (weapon, new Vector3 (this.gameObject.transform.position.x, this.gameObject.transform.position.y, 0), Quaternion.identity) as Weapon;
+            weapon.transform.SetParent (this.gameObject.transform);
         }
 
-        rbody = gameObject.GetComponent<Rigidbody2D> ();
+        rbody = this.GetComponent<Rigidbody2D> ();
+
+        movement = this.GetComponent<EnemyMovement> ();
+        movement.enabled = false;
+
+        boundingstimeout = this.GetComponent<BoundingsTimeout2D> ();
+        boundingstimeout.enabled = false;
+
+        spriterenderer = this.GetComponent<SpriteRenderer> ();
     }
     
     // Update is called once per frame
     void Update ()
     {
-        if (weapon) weapon.Shoot();
+        if (!spawned & spriterenderer.IsVisibleFrom (Camera.main))
+        {
+            Spawn ();
+        }
+        else
+        {
+            if (weapon)
+                weapon.Shoot ();
+        }
+    }
+
+    void Spawn ()
+    {
+        movement.enabled = true;
+        boundingstimeout.enabled = true;
     }
 }


### PR DESCRIPTION
EnemyMovement and BoundingsTimeout2D are disabled until it becomes visible in the main camera.

Used RequireComponent to make sure we have these scripts attached. I figured this was a tad better than checking "if script" everywhere we might need to. Note that this only works for components, this will not work for Weapon, as it is a prefab / instance and should be checked before use. Also note that this only adds components it needs when the script itself is added (if it needs to), it won't make changes after it has already been added.
#85
