### PR TITLE
Fix first wave offset

### DIFF
--- a/Assets/Editor/LevelControllerEditor.cs
+++ b/Assets/Editor/LevelControllerEditor.cs
@@ -50,22 +50,20 @@ public class LevelControllerEditor : Editor
 		// levels
 		SerializedProperty levels = serializedObject.FindProperty ("levels");
 		EditorGUILayout.PropertyField (levels);
-		if (levels.isExpanded)
-		{
+		if (levels.isExpanded) {
 			EditorGUILayout.PropertyField (levels.FindPropertyRelative ("Array.size"));
 
 			// for each level...
 			EditorGUI.indentLevel += 1;
-			for (int i = 0; i < levels.arraySize; i++)
-			{
+			for (int i = 0; i < levels.arraySize; i++) {
 				GUIContent label = new GUIContent ();
 				string name = levels.GetArrayElementAtIndex (i).FindPropertyRelative ("name").stringValue;
 				label.text = name.Length != 0 ? name : "Level " + i;
 
 				// make sure there is enough bools in the list for the foldout
-				if (levelFoldBools == null) levelFoldBools = new List<bool> ();
-				while (levelFoldBools.Count () <= i)
-				{
+				if (levelFoldBools == null)
+					levelFoldBools = new List<bool> ();
+				while (levelFoldBools.Count () <= i) {
 					levelFoldBools.Add (false);
 				}
 
@@ -74,8 +72,7 @@ public class LevelControllerEditor : Editor
 				Rect foldRect = GUILayoutUtility.GetLastRect ();
 				levelFoldBools [i] = EditorGUI.Foldout (foldRect, levelFoldBools [i], label, true);
 
-				if (levelFoldBools [i])
-				{
+				if (levelFoldBools [i]) {
 					// define level fields
 					EditorGUILayout.PropertyField (levels.GetArrayElementAtIndex (i).FindPropertyRelative ("name"));
 					// backgrounds
@@ -91,17 +88,15 @@ public class LevelControllerEditor : Editor
 					//ListOptions (levels.GetArrayElementAtIndex (i).FindPropertyRelative ("player2"), players, "Player2");
 					// waves
 					EditorGUILayout.PropertyField (levels.GetArrayElementAtIndex (i).FindPropertyRelative ("numWaves"));
-					EditorGUILayout.PropertyField(levels.GetArrayElementAtIndex (i).FindPropertyRelative ("maxTimesAWaveCanInstantiate"));
+					EditorGUILayout.PropertyField (levels.GetArrayElementAtIndex (i).FindPropertyRelative ("maxTimesAWaveCanInstantiate"));
 					EditorGUI.indentLevel += 1;
 					SerializedProperty wavelist = levels.GetArrayElementAtIndex (i).FindPropertyRelative ("waves");
 					EditorGUILayout.PropertyField (wavelist);
-					if (wavelist.isExpanded)
-					{
+					if (wavelist.isExpanded) {
 						EditorGUILayout.PropertyField (wavelist.FindPropertyRelative ("Array.size"));
 
 						// for each wave...
-						for (int j = 0; j < wavelist.arraySize; j++)
-						{
+						for (int j = 0; j < wavelist.arraySize; j++) {
 							GUIContent wavelabel = new GUIContent ();
 							wavelabel.text = "Wave " + j;
 
@@ -121,21 +116,37 @@ public class LevelControllerEditor : Editor
 	public void OnSceneGUI ()
 	{
 		LevelController levelController = target as LevelController;
-		for (int i = 0; i < 3; i++)
-		{
-			// camera square
-			var left = Camera.main.ViewportToWorldPoint (Vector3.zero).x + (levelController.waveSeparation * i);
-			var right = Camera.main.ViewportToWorldPoint (Vector3.one).x + (levelController.waveSeparation * i);
-			var top = Camera.main.ViewportToWorldPoint (Vector3.zero).y;
-			var bottom = Camera.main.ViewportToWorldPoint (Vector3.one).y;
 
-			Vector3[] cameraVerts = {
+		// draw camera
+
+		var left = Camera.main.ViewportToWorldPoint (Vector3.zero).x;
+		var right = Camera.main.ViewportToWorldPoint (Vector3.one).x;
+		var top = Camera.main.ViewportToWorldPoint (Vector3.zero).y;
+		var bottom = Camera.main.ViewportToWorldPoint (Vector3.one).y;
+
+		Vector3[] cameraVerts = {
+			new Vector3 (left, top, 0),
+			new Vector3 (right, top, 0),
+			new Vector3 (right, bottom, 0),
+			new Vector3 (left, bottom, 0)
+		};
+		Handles.DrawSolidRectangleWithOutline (cameraVerts, Color.clear, Color.white);
+
+		// draw waves
+		for (int i = 0; i < 3; i++) {
+			// camera square
+			left = Camera.main.ViewportToWorldPoint (Vector3.one).x + (levelController.waveSeparation * i) + (i == 0 ? .1f : 0);
+			right = Camera.main.ViewportToWorldPoint (Vector3.one * 2).x + (levelController.waveSeparation * i);
+			top = Camera.main.ViewportToWorldPoint (Vector3.zero).y;
+			bottom = Camera.main.ViewportToWorldPoint (Vector3.one).y;
+
+			Vector3[] waveVerts = {
 				new Vector3 (left, top, 0),
 				new Vector3 (right, top, 0),
 				new Vector3 (right, bottom, 0),
 				new Vector3 (left, bottom, 0)
 			};
-			Handles.DrawSolidRectangleWithOutline (cameraVerts, Color.clear, Color.magenta);
+			Handles.DrawSolidRectangleWithOutline (waveVerts, Color.clear, Color.magenta);
 		}
 	}
 }

--- a/Assets/Editor/LevelControllerEditor.cs
+++ b/Assets/Editor/LevelControllerEditor.cs
@@ -50,12 +50,14 @@ public class LevelControllerEditor : Editor
 		// levels
 		SerializedProperty levels = serializedObject.FindProperty ("levels");
 		EditorGUILayout.PropertyField (levels);
-		if (levels.isExpanded) {
+		if (levels.isExpanded)
+		{
 			EditorGUILayout.PropertyField (levels.FindPropertyRelative ("Array.size"));
 
 			// for each level...
 			EditorGUI.indentLevel += 1;
-			for (int i = 0; i < levels.arraySize; i++) {
+			for (int i = 0; i < levels.arraySize; i++)
+			{
 				GUIContent label = new GUIContent ();
 				string name = levels.GetArrayElementAtIndex (i).FindPropertyRelative ("name").stringValue;
 				label.text = name.Length != 0 ? name : "Level " + i;
@@ -63,7 +65,8 @@ public class LevelControllerEditor : Editor
 				// make sure there is enough bools in the list for the foldout
 				if (levelFoldBools == null)
 					levelFoldBools = new List<bool> ();
-				while (levelFoldBools.Count () <= i) {
+				while (levelFoldBools.Count () <= i)
+				{
 					levelFoldBools.Add (false);
 				}
 
@@ -72,7 +75,8 @@ public class LevelControllerEditor : Editor
 				Rect foldRect = GUILayoutUtility.GetLastRect ();
 				levelFoldBools [i] = EditorGUI.Foldout (foldRect, levelFoldBools [i], label, true);
 
-				if (levelFoldBools [i]) {
+				if (levelFoldBools [i])
+				{
 					// define level fields
 					EditorGUILayout.PropertyField (levels.GetArrayElementAtIndex (i).FindPropertyRelative ("name"));
 					// backgrounds
@@ -92,11 +96,13 @@ public class LevelControllerEditor : Editor
 					EditorGUI.indentLevel += 1;
 					SerializedProperty wavelist = levels.GetArrayElementAtIndex (i).FindPropertyRelative ("waves");
 					EditorGUILayout.PropertyField (wavelist);
-					if (wavelist.isExpanded) {
+					if (wavelist.isExpanded)
+					{
 						EditorGUILayout.PropertyField (wavelist.FindPropertyRelative ("Array.size"));
 
 						// for each wave...
-						for (int j = 0; j < wavelist.arraySize; j++) {
+						for (int j = 0; j < wavelist.arraySize; j++)
+						{
 							GUIContent wavelabel = new GUIContent ();
 							wavelabel.text = "Wave " + j;
 
@@ -133,7 +139,8 @@ public class LevelControllerEditor : Editor
 		Handles.DrawSolidRectangleWithOutline (cameraVerts, Color.clear, Color.white);
 
 		// draw waves
-		for (int i = 0; i < 3; i++) {
+		for (int i = 0; i < 3; i++)
+		{
 			// camera square
 			left = Camera.main.ViewportToWorldPoint (Vector3.one).x + (levelController.waveSeparation * i) + (i == 0 ? .1f : 0);
 			right = Camera.main.ViewportToWorldPoint (Vector3.one * 2).x + (levelController.waveSeparation * i);

--- a/Assets/Editor/LevelControllerEditor.cs
+++ b/Assets/Editor/LevelControllerEditor.cs
@@ -63,8 +63,7 @@ public class LevelControllerEditor : Editor
 				label.text = name.Length != 0 ? name : "Level " + i;
 
 				// make sure there is enough bools in the list for the foldout
-				if (levelFoldBools == null)
-					levelFoldBools = new List<bool> ();
+				if (levelFoldBools == null) levelFoldBools = new List<bool> ();
 				while (levelFoldBools.Count () <= i)
 				{
 					levelFoldBools.Add (false);

--- a/Assets/LevelController.cs
+++ b/Assets/LevelController.cs
@@ -51,20 +51,23 @@ public class LevelController : MonoBehaviour
 
 		// instantiate background
 		GameObject background = Resources.Load (JoinPaths (backgroundsFolder, level.background)) as GameObject;
-		if (background) {
+		if (background)
+		{
 			Instantiate (background, Vector3.zero, Quaternion.identity);
 		}
 
 		// instantiate middleground
 		GameObject middleground = Resources.Load (JoinPaths (middlegroundsFolder, level.middleground)) as GameObject;
-		if (middleground) {
+		if (middleground)
+		{
 			Instantiate (middleground, Vector3.zero, Quaternion.identity);
 		}
 
 		// instantiate foreground
 		// instantiate player ? (will need to add this probably, though it will grab this from player choice...)
 		GameObject foreground = Resources.Load (JoinPaths (foregroundsFolder, level.foreground)) as GameObject;
-		if (foreground) {
+		if (foreground)
+		{
 			GameObject instantiatedForeground = Instantiate (foreground, Vector3.zero, Quaternion.identity) as GameObject;
 
 			GameObject player1 = Resources.Load (JoinPaths (playersFolder, level.player1)) as GameObject;
@@ -73,16 +76,19 @@ public class LevelController : MonoBehaviour
 		}
 
 		// instantiate waves randomly
-		if (level.numWaves / level.maxTimesAWaveCanInstantiate > level.waves.Length) {
+		if (level.numWaves / level.maxTimesAWaveCanInstantiate > level.waves.Length)
+		{
 			Debug.Log ("Numer of waves and max times a wave can instantiate do not fit with the length of wave types that can be in this level");
 		}
 
 		int[] waveCount = new int [level.numWaves]; // keep track of what r initially lands on to make sure that waves can only be instantiated the maxTimesAWaveCanInstantiate
-		for (int i = 0; i < level.numWaves; i++) {
+		for (int i = 0; i < level.numWaves; i++)
+		{
 			int r = UnityEngine.Random.Range (0, level.waves.Length);
 
 			// if r lands on a wave that has been instantiated the max number of times, increment r until a wave that can be instantiated is found
-			while (waveCount [r] > level.maxTimesAWaveCanInstantiate) {
+			while (waveCount [r] > level.maxTimesAWaveCanInstantiate)
+			{
 				if (r == level.numWaves - 1)
 					r = 0;
 				else
@@ -90,7 +96,8 @@ public class LevelController : MonoBehaviour
 			}
 
 			GameObject wave = Resources.Load (JoinPaths (wavesFolder, level.waves [r])) as GameObject;
-			if (wave) {
+			if (wave)
+			{
 				Instantiate (wave, (Camera.main.ViewportToWorldPoint (new Vector3 (1, 0, 0)) * 2) + new Vector3 (waveSeparation * i, 0), Quaternion.identity);
 				waveCount [r]++;
 			}

--- a/Assets/LevelController.cs
+++ b/Assets/LevelController.cs
@@ -51,23 +51,20 @@ public class LevelController : MonoBehaviour
 
 		// instantiate background
 		GameObject background = Resources.Load (JoinPaths (backgroundsFolder, level.background)) as GameObject;
-		if (background)
-		{
+		if (background) {
 			Instantiate (background, Vector3.zero, Quaternion.identity);
 		}
 
 		// instantiate middleground
 		GameObject middleground = Resources.Load (JoinPaths (middlegroundsFolder, level.middleground)) as GameObject;
-		if (middleground)
-		{
+		if (middleground) {
 			Instantiate (middleground, Vector3.zero, Quaternion.identity);
 		}
 
 		// instantiate foreground
 		// instantiate player ? (will need to add this probably, though it will grab this from player choice...)
 		GameObject foreground = Resources.Load (JoinPaths (foregroundsFolder, level.foreground)) as GameObject;
-		if (foreground)
-		{
+		if (foreground) {
 			GameObject instantiatedForeground = Instantiate (foreground, Vector3.zero, Quaternion.identity) as GameObject;
 
 			GameObject player1 = Resources.Load (JoinPaths (playersFolder, level.player1)) as GameObject;
@@ -76,19 +73,16 @@ public class LevelController : MonoBehaviour
 		}
 
 		// instantiate waves randomly
-		if (level.numWaves / level.maxTimesAWaveCanInstantiate > level.waves.Length)
-		{
-			Debug.Log("Numer of waves and max times a wave can instantiate do not fit with the length of wave types that can be in this level");
+		if (level.numWaves / level.maxTimesAWaveCanInstantiate > level.waves.Length) {
+			Debug.Log ("Numer of waves and max times a wave can instantiate do not fit with the length of wave types that can be in this level");
 		}
 
-		int [] waveCount = new int [level.numWaves]; // keep track of what r initially lands on to make sure that waves can only be instantiated the maxTimesAWaveCanInstantiate
-		for (int i = 0; i < level.numWaves; i++)
-		{            
+		int[] waveCount = new int [level.numWaves]; // keep track of what r initially lands on to make sure that waves can only be instantiated the maxTimesAWaveCanInstantiate
+		for (int i = 0; i < level.numWaves; i++) {
 			int r = UnityEngine.Random.Range (0, level.waves.Length);
 
 			// if r lands on a wave that has been instantiated the max number of times, increment r until a wave that can be instantiated is found
-			while (waveCount [r] > level.maxTimesAWaveCanInstantiate)
-			{
+			while (waveCount [r] > level.maxTimesAWaveCanInstantiate) {
 				if (r == level.numWaves - 1)
 					r = 0;
 				else
@@ -96,9 +90,8 @@ public class LevelController : MonoBehaviour
 			}
 
 			GameObject wave = Resources.Load (JoinPaths (wavesFolder, level.waves [r])) as GameObject;
-			if (wave)
-			{
-				Instantiate (wave, new Vector3 (waveSeparation * (i + 1), 0), Quaternion.identity);
+			if (wave) {
+				Instantiate (wave, (Camera.main.ViewportToWorldPoint (new Vector3 (1, 0, 0)) * 2) + new Vector3 (waveSeparation * i, 0), Quaternion.identity);
 				waveCount [r]++;
 			}
 		}


### PR DESCRIPTION
First wave now always spawns directly outside of the screen. Following waves are offset from this first wave. Overlapping waves is still possible. (I figure since you can view whether or not waves will be overlapping that it is up to the user to determine proper distance and allow overlap if they choose).
#110
